### PR TITLE
Portability Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ test
 ylwrap
 src_py/__pycache__
 src_py/.deps
+/configure~

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -12,4 +12,5 @@ Makefile
 Makefile.in
 default.cvcrc
 cvc.exe
+cvc
 autoscan*

--- a/src/CvcTypes.hh
+++ b/src/CvcTypes.hh
@@ -24,12 +24,12 @@
 #ifndef CVCTYPES_HH_
 #define CVCTYPES_HH_
 
-#include <stdint-gcc.h>
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <cstring>
 #include <stdexcept>
-#include <malloc.h>
+#include <cstdlib>
 #include <unordered_map>
 
 #ifndef INT64_MAX

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@
 CFLAGS = -O3 
 CXXFLAGS = -O3 -std=gnu++11
 #LIBS = -lz -lreadline -lcurses -lhistory -lintl
-LIBS = -lz -lreadline -lcurses -lhistory 
+LIBS = -lz -lreadline -lcurses -lhistory $(INTLLIBS)
 LDFLAGS = -static-libstdc++ -static-libgcc
 
 # this lists the binaries to produce, the (non-PHONY, binary) targets in


### PR DESCRIPTION
These are a small number of changes that allow cvc to compile on more platforms.

* malloc.h is not standard and was replaced with cstdlib
* stdint-gcc.h has been superseded by cstdint
* INTLLIBS added explicitly (not found on macOS otherwise)

This does not enable compilation using Clang: obstack just wouldn't have it. But it allows it to compile on macOS reasonably