### PR TITLE
Changes for version 1.1.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT(CVC, [1.1.1], [cvc@shuharisystem.com])
+AC_INIT(CVC, [1.1.2], [cvc@shuharisystem.com])
 AC_CONFIG_SRCDIR(src)
 AC_CONFIG_HEADERS([config.h])
 AC_USE_SYSTEM_EXTENSIONS

--- a/src/CCvcDb_utility.cc
+++ b/src/CCvcDb_utility.cc
@@ -1056,6 +1056,7 @@ void CCvcDb::Cleanup() {
 	if ( errorFile.is_open() ) errorFile.close();
 	if ( debugFile.is_open() ) debugFile.close();
 	RemoveLock();
+#ifdef CVC_MEMORY_DEBUG
 	try {
 		cvcParameters.cvcPowerPtrList.Clear(leakVoltagePtr_v, netVoltagePtr_v, netCount);  // defined power deleted here
 		if ( gDebug_cvc ) cout << "Cleared power pointer list" << endl;
@@ -1089,6 +1090,7 @@ void CCvcDb::Cleanup() {
 	catch (...) {  // ignore errors freeing malloc memory
 		cout << "INFO: problem with memory cleanup" << endl;
 	}
+#endif
 }
 
 deviceId_t CCvcDb::CountBulkConnections(netId_t theNetId) {

--- a/src/Cvc.hh
+++ b/src/Cvc.hh
@@ -24,7 +24,7 @@
 #ifndef CVC_H_
 #define CVC_H_
 
-#define CVC_VERSION "1.1.1"
+#define CVC_VERSION "1.1.2"
 
 extern bool gDebug_cvc;
 extern bool gSetup_cvc;


### PR DESCRIPTION
CVC: Allow both SCRC power and SCRC ground in same logic.
CVC: Ignore gate-source errors for SCRC nets.
CVC: For calculated voltages, when CVC_LOGIC_DIODE is true, instead of pmos gate-source error, expect sim voltage low.
CVC: Don't explicitly release memory at program termination unless debug mode. (was causing core dumps).