### PR TITLE
Changes for version 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation
 Requirements:
 - gcc 4.9.3
 - python 2.7.10
-- bison 3.0.1 (only if making changes to parser or compiling from github)
+- bison 3.3 (only if making changes to the parser or compiling from github)
 
 GUI requirements:
 - kivy 1.10.0

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT(CVC, [1.1.2], [cvc@shuharisystem.com])
+AC_INIT(CVC, [1.1.3], [cvc@shuharisystem.com])
 AC_CONFIG_SRCDIR(src)
 AC_CONFIG_HEADERS([config.h])
 AC_USE_SYSTEM_EXTENSIONS

--- a/src/CConnection.hh
+++ b/src/CConnection.hh
@@ -156,6 +156,7 @@ public:
 	void SetUnknownVoltage();
 	void SetMinMaxLeakVoltagesAndFlags(CCvcDb * theCvcDb);
 	bool IsPossibleHiZ(CCvcDb * theCvcDb);
+	bool HasParallelShort(CCvcDb * theCvcDb);
 	bool IsTransferGate(deviceId_t theNmos, deviceId_t thePmos, CCvcDb * theCvcDb);
 	bool IsPumpCapacitor();
 

--- a/src/Cvc.hh
+++ b/src/Cvc.hh
@@ -24,7 +24,7 @@
 #ifndef CVC_H_
 #define CVC_H_
 
-#define CVC_VERSION "1.1.2"
+#define CVC_VERSION "1.1.3"
 
 extern bool gDebug_cvc;
 extern bool gSetup_cvc;


### PR DESCRIPTION
Do not flag Hi-Z input errors if the source and drain are shorted.
Upped the bison(yacc) version required.