### PR TITLE
Inverter loop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-fC_INIT(CVC_RV, [1.1.6], [cvc@shuharisystem.com])
+AC_INIT(CVC_RV, [1.1.6], [cvc@shuharisystem.com])
 AC_CONFIG_SRCDIR(src)
 AC_CONFIG_HEADERS([config.h])
 AC_USE_SYSTEM_EXTENSIONS

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT(CVC_RV, [1.1.5], [cvc@shuharisystem.com])
+fC_INIT(CVC_RV, [1.1.6], [cvc@shuharisystem.com])
 AC_CONFIG_SRCDIR(src)
 AC_CONFIG_HEADERS([config.h])
 AC_USE_SYSTEM_EXTENSIONS

--- a/src/CCvcDb.cc
+++ b/src/CCvcDb.cc
@@ -2349,47 +2349,35 @@ void CCvcDb::CheckConnections() {
 	}
 }
 
-void CCvcDb::SetInverterHighLow(netId_t theNetId, netId_t theMaxNetId) {
-	static int myLoopCount = 0;
+void CCvcDb::SetInverterHighLow(netId_t theNetId, set<netId_t> & theInverterNets, netId_t theLoopCount) {
 	bool myDebug = false;
-	if ( ++myLoopCount > netCount ) {
-		// Original theMaxNetId might be outside of loop. This will cause recursive subroutine overflow.
-		// This detects the recursion past the total net counts and resets theMaxNetId.
-		theMaxNetId = theNetId;
-		myLoopCount = 0;
-	}
 	if ( inverterNet_v[theNetId] == UNKNOWN_NET ) {
-		myLoopCount = 0;
 		return;
-	} else if ( inverterNet_v[theNetId] == theMaxNetId ) { // prevent looping
-		myLoopCount = 0;
+	} else if ( theInverterNets.count(theNetId) > 0 ) { // prevent looping
 		return;
 	} else {
+		if ( (theLoopCount & 1023) == 0 ) { // add first and every 1024th net to the loop check
+			theInverterNets.insert(theNetId);
+		}
 		netId_t myInputId = inverterNet_v[theNetId];
-		SetInverterHighLow(myInputId, max(theMaxNetId, myInputId));
+		SetInverterHighLow(myInputId, theInverterNets, theLoopCount + 1);
 		highLow_v[theNetId] = ! highLow_v[myInputId];
 		if ( myDebug ) cout << "Net " << theNetId << " input " << inverterNet_v[theNetId] << " " << highLow_v[theNetId] << " " << myInputId << endl;
 	}
 }
 
-netId_t CCvcDb::SetInverterInput(netId_t theNetId, netId_t theMaxNetId) {
-	static int myLoopCount = 0;
+netId_t CCvcDb::SetInverterInput(netId_t theNetId, set<netId_t> & theInverterNets, netId_t theLoopCount) {
 	bool myDebug = false;
-	if ( ++myLoopCount > netCount ) {
-		// Original theMaxNetId might be outside of loop. This will cause recursive subroutine overflow.
-		// This detects the recursion past the total net counts and resets theMaxNetId.
-		theMaxNetId = theNetId;
-		myLoopCount = 0;
-	}
 	if ( inverterNet_v[theNetId] == UNKNOWN_NET ) {
-		myLoopCount = 0;
 		return(theNetId);
-	} else if ( inverterNet_v[theNetId] == theMaxNetId ) { // prevent looping
-		myLoopCount = 0;
-		return(theMaxNetId);
+	} else if ( theInverterNets.count(theNetId) > 0 ) { // prevent looping
+		return(theNetId);
 	} else {
+		if ( (theLoopCount & 1023) == 0 ) { // add first and every 1024th net to the loop check
+			theInverterNets.insert(theNetId);
+		}
 		netId_t myInputId = inverterNet_v[theNetId];
-		inverterNet_v[theNetId] = SetInverterInput(myInputId, max(theMaxNetId, myInputId));
+		inverterNet_v[theNetId] = SetInverterInput(myInputId, theInverterNets, theLoopCount + 1);
 		if ( myDebug ) cout << "Net " << theNetId << " input " << inverterNet_v[theNetId] << " " << highLow_v[theNetId] << " " << myInputId << endl;
 		return(inverterNet_v[theNetId]);
 	}
@@ -2400,20 +2388,22 @@ void CCvcDb::SetInverters() {
 	for( netId_t net_it = 0; net_it < netCount; net_it++ ) {
 		if ( net_it != GetEquivalentNet(net_it) ) continue;
 		myDebug = false;
+		set<netId_t> myInverterNets;
 		if ( myDebug ) cout << endl << "Starting " << net_it << endl;
 		if ( inverterNet_v[net_it] != UNKNOWN_NET ) {
 			netId_t myInputId = inverterNet_v[net_it];
-			SetInverterHighLow(myInputId, max(net_it, myInputId));
+			SetInverterHighLow(myInputId, myInverterNets, 0);
 			highLow_v[net_it] = ! highLow_v[myInputId];
 		}
 	}
 	for( netId_t net_it = 0; net_it < netCount; net_it++ ) {
 		if ( net_it != GetEquivalentNet(net_it) ) continue;
 		myDebug = false;
+		set<netId_t> myInverterNets;
 		if ( myDebug ) cout << endl << "Starting " << net_it << endl;
 		if ( inverterNet_v[net_it] != UNKNOWN_NET ) {
 			netId_t myInputId = inverterNet_v[net_it];
-			inverterNet_v[net_it] = SetInverterInput(myInputId, max(net_it, myInputId));
+			inverterNet_v[net_it] = SetInverterInput(myInputId, myInverterNets, 0);
 		}
 	}
 }

--- a/src/CCvcDb.hh
+++ b/src/CCvcDb.hh
@@ -305,8 +305,8 @@ public:
 	void IgnoreUnusedDevices();
 	void SetSimPower(propagation_t thePropagationType, CNetIdSet & theNewNetSet = EmptySet);
 
-	void SetInverterHighLow(netId_t theNetId, netId_t theMaxNetId);
-	netId_t SetInverterInput(netId_t theNetId, netId_t theMaxNetId);
+	void SetInverterHighLow(netId_t theNetId, set<netId_t> & theInverterNets, netId_t theLoopCount);
+	netId_t SetInverterInput(netId_t theNetId, set<netId_t> & theInverterNets, netId_t theLoopCount);
 	void SetInverters();
 
 	// CCvcDb-utility

--- a/src/Cvc.hh
+++ b/src/Cvc.hh
@@ -24,7 +24,7 @@
 #ifndef CVC_H_
 #define CVC_H_
 
-#define CVC_VERSION "1.1.5"
+#define CVC_VERSION "1.1.6"
 
 extern bool gDebug_cvc;
 extern bool gSetup_cvc;


### PR DESCRIPTION
Previously, a single net from the inverter chain was used to detect loops.
However, if that net was outside of the loop, the program would recursively call
itself up to net_count times. This could lead to OOM errors.

This change keeps a set of nets (the first and each 1024th net thereafter) to
check for loops.